### PR TITLE
Add curl in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jre-alpine
 
 COPY bootstrap/target/hesperides-*.jar hesperides.jar
+RUN apk install curl
 
 ENTRYPOINT ["/usr/bin/java"]
 


### PR DESCRIPTION
To get healthcheck works we need to have curl binary in the container
